### PR TITLE
fix: remove space between "author" and colon

### DIFF
--- a/title.tex
+++ b/title.tex
@@ -45,7 +45,7 @@
     
     \vspace*{1.5cm}
     {\large
-    \ifmmtlanguagegerman AutorIn \else Author \fi: \authorname
+    \ifmmtlanguagegerman AutorIn: \else Author: \fi \authorname
     }
     \vfill
     


### PR DESCRIPTION
Currently the template renders "Author : Marcel Freinbichler"

This commit removes the space to render "Author: Marcel Freinbichler"