### PR TITLE
Fix affidavit

### DIFF
--- a/affidavit.tex
+++ b/affidavit.tex
@@ -3,7 +3,7 @@
 \subsection*{Eidesstattliche Erklärung}
 
 
-Ich erkläre hiermit eidesstattlich, dass  ich  die vorliegende Arbeit selbstständig  und ohne fremde Hilfe verfasst, und keine  anderen  als die angegebenen Quellen und  Hilfsmittel benutzt  habe. Weiter versichere ich hiermit, dass ich   die den benutzten Quellen  wörtlich oder inhaltlich entnommenen Stellen als solche kenntlich gemacht habe.
+Ich erkläre hiermit eidesstattlich, dass ich die vorliegende Arbeit selbstständig und ohne fremde Hilfe verfasst, und keine anderen als die angegebenen Quellen und Hilfsmittel benutzt habe. Weiter versichere ich hiermit, dass ich die den benutzten Quellen wörtlich oder inhaltlich entnommenen Stellen als solche kenntlich gemacht habe.
 
 Die Arbeit wurde bisher in gleicher oder ähnlicher Form keiner anderen Prüfungskommission weder im In- noch im Ausland vorgelegt und auch nicht veröffentlicht.
 

--- a/affidavit.tex
+++ b/affidavit.tex
@@ -3,7 +3,7 @@
 \subsection*{Eidesstattliche Erklärung}
 
 
-Ich erkläre hiermit eidesstattlich, dass  ich  die vorliegende Arbeit selbständig  und ohne fremde Hilfe verfasst, und keine  anderen  als die angegebenen Quellen und  Hilfsmittel benutzt  habe. Weiter versichere ich hiermit, dass ich   die den benutzten Quellen  wörtlich oder inhaltlich entnommenen Stellen als solche kenntlich gemacht habe.
+Ich erkläre hiermit eidesstattlich, dass  ich  die vorliegende Arbeit selbstständig  und ohne fremde Hilfe verfasst, und keine  anderen  als die angegebenen Quellen und  Hilfsmittel benutzt  habe. Weiter versichere ich hiermit, dass ich   die den benutzten Quellen  wörtlich oder inhaltlich entnommenen Stellen als solche kenntlich gemacht habe.
 
 Die Arbeit wurde bisher in gleicher oder ähnlicher Form keiner anderen Prüfungskommission weder im In- noch im Ausland vorgelegt und auch nicht veröffentlicht.
 

--- a/affidavit.tex
+++ b/affidavit.tex
@@ -3,7 +3,7 @@
 \subsection*{Eidesstattliche Erklärung}
 
 
-Ich erkläre hiermit eidesstattlich, dass  ich  die vorliegende Arbeit selbständig  und ohne fremde Hilfe verfasst, und keine  anderen  als die angegeben Quellen und  Hilfsmittel benutzt  habe. Weiter versichere ich hiermit, dass ich   die den benutzten Quellen  wörtlich oder inhaltlich entnommenen Stellen als solche kenntlich gemacht habe.
+Ich erkläre hiermit eidesstattlich, dass  ich  die vorliegende Arbeit selbständig  und ohne fremde Hilfe verfasst, und keine  anderen  als die angegebenen Quellen und  Hilfsmittel benutzt  habe. Weiter versichere ich hiermit, dass ich   die den benutzten Quellen  wörtlich oder inhaltlich entnommenen Stellen als solche kenntlich gemacht habe.
 
 Die Arbeit wurde bisher in gleicher oder ähnlicher Form keiner anderen Prüfungskommission weder im In- noch im Ausland vorgelegt und auch nicht veröffentlicht.
 


### PR DESCRIPTION
- Fixed a grammatical typo "die angegeben Quellen" -> "die angegebenen Quellen"
- Newer Spelling recommends "selbstständig" instead of "selbständig", e.g. [Duden](https://www.duden.de/rechtschreibung/selbststaendig) prefers it but this could opinionated
- Removed additional whitespaces